### PR TITLE
Implement basic, somewhat workable collision resolution

### DIFF
--- a/src/engine/chunk_manager.rs
+++ b/src/engine/chunk_manager.rs
@@ -61,7 +61,7 @@ impl<T: Voxel + Clone + Send + Sync + 'static> ChunkManager<T> {
                 // the lifetime of the program (or a panic), and in either case, we want to
                 // end this thread.
                 chunk_tx.send((request, generator.generate(request))).unwrap();
-            }    
+            }
         });
 
         let mut manager = ChunkManager {
@@ -199,13 +199,13 @@ impl<T: Voxel + Clone + Send + Sync + 'static> ChunkManager<T> {
                 .map(|(pos, opt)| (*pos, opt.unwrap()))
                 .take(4)
                 .collect::<Vec<_>>();
-            
+
             // The heavy-lifting parallel iterator that iterates the meshers in parallel
             // and generates the mesh data
             let meshes = meshers.into_par_iter()
                 .map(|(pos, mesher)| (pos, mesher.gen_vertex_data()))
                 .collect::<Vec<_>>();
-            
+
             // Iterate the generated meshes, construct the actual mesh (the one with the
             // actual vertex and index buffer), and insert them into the mesh map.
             // NOTE: We need to construct the mesh on the main OpenGL thread.
@@ -228,14 +228,14 @@ impl<T: Voxel + Clone + Send + Sync + 'static> ChunkManager<T> {
                 .map(|pos| (pos, self.get_mesher(pos)))
                 .filter_map(|(pos, mesher)| mesher.map(|m| (pos, m.gen_mesh().unwrap())))
                 .collect::<Vec<_>>();
-            
+
             for (pos, mesh) in meshes {
                 self.meshes.insert(pos, mesh);
             }
         }
     }
 
-    fn get_voxel(&self, pos: Vector3<i32>) -> Option<&T> {
+    pub fn get_voxel(&self, pos: Vector3<i32>) -> Option<&T> {
         let (cpos, bpos) = get_chunk_pos(pos);
         if let Some(chunk) = self.chunks.get(&cpos) {
             let pos = (bpos.x as usize, bpos.y as usize, bpos.z as usize);


### PR DESCRIPTION
I don't intend for you to actually merge this, but figure it's an easy way to see the diffs and test (it looks like some trailing white space got removed, so the diffs kinda ugly).

There's a number of issues, namely the player still sticks to things kind of, you can fly upwards from inside tunnels (there's no collision on the player's upper body), and jumping is "hacked" on because I figured I'd leave that up to you.

I wrote it in main just for simplicity's sake but of course you'd probably want to refactor that, along with I think there's a few extra branches than necessary. The basic algorithm is "resolve Y axis, then check blocks at the player's level (XZ axis)." Substepping should reduce tunneling but I don't really see the effect of it yet. I will have to look up later how physics engines typically resolve collisions, I believe it's usually by applying an impulse, which should give you sliding for free.