### PR TITLE
Remove `int_hash` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ serde_derive = "1.0"
 serde_json = "1.0"
 crossbeam = "0.5.0"
 rodio = "0.8.1"
-int_hash = "0.1.1"
 
 [dependencies.specs]
 version = "0.12.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,6 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate crossbeam;
-extern crate int_hash;
 extern crate rodio;
 extern crate serde_json;
 extern crate simple_logger;


### PR DESCRIPTION
It is currently unused (tested by running),
and has been yanked, so prevents building.

Author recommends using https://github.com/rust-lang/rustc-hash,
also used by the compiler.

This wouldn't prevent building if the lockfile was in the repository, but it is in `.gitignore` by default.